### PR TITLE
Update TabBarBottom to accept styling for animations

### DIFF
--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -41,6 +41,7 @@ type Props = {
   getTestIDProps: (scene: TabScene) => (scene: TabScene) => any,
   renderIcon: (scene: TabScene) => React.Node,
   style?: ViewStyleProp,
+  animateStyle?: ViewStyleProp,
   labelStyle?: TextStyleProp,
   tabStyle?: ViewStyleProp,
   showIcon?: boolean,
@@ -203,6 +204,7 @@ class TabBarBottom extends React.PureComponent<Props, State> {
       activeBackgroundColor,
       inactiveBackgroundColor,
       style,
+      animateStyle,
       tabStyle,
       isLandscape,
     } = this.props;
@@ -219,7 +221,7 @@ class TabBarBottom extends React.PureComponent<Props, State> {
     ];
 
     return this.state.isVisible ? (
-      <Animated.View>
+      <Animated.View style={animateStyle}>
         <SafeAreaView
           style={tabBarStyle}
           forceInset={{ bottom: 'always', top: 'never' }}


### PR DESCRIPTION
### Current
When an animated style is applied to the component, the component throws the same error as when styles are applied to a normal non-animated `View`.

### Fix
Styles passed to the component are passed down to the `Animated.View` via the prop `animateStyles`, allowing the TabBarBottom to be animated.

**Test plan (required)**

Unit test on props passing through to children.